### PR TITLE
Update schema to reflect available data from BAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 - `rocc.xml` is a sample (dummy) XML file that contains a scheleton of how a file in `ROCC` format may look like. It validates against schema files.
 - `rocc.xsd` contains the definition of the `ROCC` schema in the XSD format. This file is generated from `rocc.rnc`.
 
-## Building the Docker image ##
+## Docker image ##
 
-In order to generate schema files int the XSD and RelaxNG format from the compact syntax schema definition (`rocc.rnc`) you will need to use [`jing`](https://relaxng.org/jclark/jing.html) utility. To avoid polluting your workstation this can be done using a Docker container.
+In order to generate schema files in the XSD and RelaxNG format from the compact syntax schema definition (`rocc.rnc`) you will need to use [`trang`](https://relaxng.org/jclark/trang.html) utility. To avoid polluting your workstation this can be done using a Docker container.
 
 The [`Dockerfile`](./Dockerfile) creates a Docker image based on Ubuntu 20.04, installs `OpenJdk` on it and builds the `jing` and `trang` utilities used for validating a file against a schema and respectively, generating XSD and RelaxNG schemas from the compact syntax schema.
 
@@ -20,6 +20,21 @@ To build the image, navigate to the directory containing the `Dockerfile` and ru
 ```sh
 docker build -t rocc .
 ```
+
+### Converting schemas ###
+To convert from RelaxNG compact syntax (`.rnc`) to RelaxNG syntax (`.rng`) run:
+```sh
+docker run --rm -v <path-to-this-repo>:/work rocc -jar /opt/jing-trang/trang.jar -I rnc -O rng /work/rocc.rnc /work/rocc.rng
+```
+
+To convert from RelaxNG compact syntax (`.rnc`) to XSD (`.xsd`) run:
+```sh
+docker run --rm -v <path-to-this-repo>:/work rocc -jar /opt/jing-trang/trang.jar -I rnc -O xsd /work/rocc.rnc /work/rocc.xsd
+```
+
+Make sure to replace `<path-to-this-repo>` with the path where the repository resides.
+
+The commands above will spin a Docker container from the image named `rocc`, will mount the curent repository (located at `<path-to-this-repo>`) inside the `/work` directory in the container, and will generate the output schema in the desired format by calling the `trang` utility.
 
 ## Validating a xml file against the ROCC schema ##
 

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -31,7 +31,8 @@ grammar {
 			       scannedCopy,
 			       creation,
 			       publishing,
-			       description
+			       contentDescription,
+			       formatDescription*
 			   }
 
   imagesOfPages = element imagesOfPages{
@@ -167,10 +168,17 @@ grammar {
 			   }?
 		       }
 
-  description = element description {
-		    attribute style { "Juridic-administrativ" | "Bisericesc"| "Științific" | "Beletristic" | "Publicistic" },
-		    attribute subject { text }?
-		}
+  contentDescription = element contentDescription {
+			   attribute style { text },
+			   element subject { text }?
+		       }
+
+  formatDescription = element formatDescription {
+			  element content {
+			      attribute id { text },
+			      text
+			  }
+		      }
 
   onePageImage = element onePageImage {
 		     attribute pageID { text },

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -107,11 +107,34 @@ grammar {
 		}
 
   creation = element creation {
-		 attribute author { text },
 		 attribute creationYear { text },
-		 attribute secAuthors { text },
+		 author?,
+		 secondaryAuthor*,
 		 creationLocation?
              }
+
+  author = element author {
+	       attribute name { text }?,
+	       attribute surname { text }?,
+	       attribute content { text }?,
+	       element addToName { text }?,
+	       element bio { text }?
+	   }
+
+  secondaryAuthor = element secAuthor {
+			attribute id { text },
+			attribute name { text }?,
+			attribute surname { text }?,
+			attribute authority { text }?,
+			element addToName {
+			    attribute id { text },
+			    text
+			}?,
+			element bio {
+			    attribute id { text },
+			    text
+			}?
+		    }
 
   creationLocation =  element creationLocation {
 			  attribute creationProvince { "Moldova" | "Țara Românească" | "Transilvania" },

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -62,16 +62,6 @@ grammar {
 				sequenceOnePageAlignments+
 			    }
 
-  ## Represents the zone of the origin of the document.
-  ## The value can any combination of the following:
-  ## MD = Moldavia
-  ## W = Wallachia
-  ## T = Transylvania
-  ## MM = Maramureș
-  ## BT = Banat
-  ## BS = Bessarabia (for dates between 1812 - 1899)
-  rocCodeZone = list{ ("MD" | "W" | "T" | "MM" | "BT" | "BS")+ }
-
   roccCode = element ROCC-code {
 		 attribute difficultyLevel { "1" | "2" | "3" },
 		 attribute writingType { "print" | "uncial" | "manuscript" },
@@ -79,7 +69,7 @@ grammar {
 		 attribute century { "XVI" | "XVII" | "XVIII" | "XIX" },
 		 attribute fiftyYears { "1" | "2" },
 		 attribute printingYear { xsd:integer },
-		 attribute zone { rocCodeZone }
+		 attribute locationRoot { xsd:anyURI }
 	     }
 
   translation = element translation {

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -62,15 +62,36 @@ grammar {
   seqAlignmentsImage2Text = element seqAlignmentsImage2Text {
 				sequenceOnePageAlignments+
 			    }
+  ## Represents the zone of the origin of the document.
+  ## The value can any combination of the following:
+  ## MD = Moldavia
+  ## W  = Wallachia
+  ## T  = Transylvania
+  ## MM = Maramureș
+  ## BT = Banat
+  ## BS = Bessarabia (for dates between 1812 - 1899)
+  roccCodeZone = list{ ("MD" | "W" | "T" | "MM" | "BT" | "BS")+ }
 
   roccCode = element ROCC-code {
 		 attribute difficultyLevel { "1" | "2" | "3" },
-		 attribute writingType { "print" | "uncial" | "manuscript" },
-		 attribute annotationLevel { "original" | "gold" | "test" | "mixt" },
+		 ## Denotes the type of writing of the page collection.
+		 ## Values for writingType attribute are:
+		 ## - p  = print;
+		 ## - u  = uncial;
+		 ## - su = semiuncial;
+		 ## - m  = manuscript.
+		 attribute writingType { "p" | "u" | "su" | "m" },
+		 ## Denotes the annotation of the page collection.
+		 ## Values for annotationLevel attribute are:
+		 ## - o = original, unannotated;
+		 ## - g = gold - annotated fully or partially by experts;
+		 ## - t = test - annotated by the application;
+		 ## - m = mixt - annotated by both experts and applications.
+		 attribute annotationLevel { "o" | "g" | "t" | "m" },
 		 attribute century { "XVI" | "XVII" | "XVIII" | "XIX" },
 		 attribute fiftyYears { "1" | "2" },
 		 attribute printingYear { xsd:integer },
-		 attribute locationRoot { xsd:anyURI }
+		 attribute zone { roccCodeZone }
 	     }
 
   translation = element translation {

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -6,7 +6,7 @@ grammar {
   start = ROCC
 
   # Root element of the ROCC file.
-  ROCC = element ROCC { pageCollection}
+  ROCC = element ROCC { pageCollection+ }
 
   pageCollection = element pageCollection {
 		       attribute id { text },

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -143,14 +143,28 @@ grammar {
 
   publishing = element publishing {
 		   attribute publishingYear { xsd:integer },
+		   attribute publisher { text },
+		   attribute noOfPagesOrSheets { xsd:integer },
+		   attribute pageOrSheet { "page" | "sheet" },
+		   element dimensions {
+		       attribute units { "mm" | "cm" },
+		       attribute width { xsd:decimal },
+		       attribute height { xsd:decimal }
+		   },
 		   publishingLocation?
                }
 
   publishingLocation = element publishingLocation {
-			   attribute publishingCountry { text }?,
 			   attribute publishingProvince { "Moldova" | "Țara Românească" | "Basarabia" | "Transilvania" },
-			   attribute publishingHouse { text }?,
-			   attribute publishingTown { text }?
+			   attribute publishingTown { text }?,
+			   element publishingHouse {
+			       attribute id { text },
+			       text
+			   }?,
+			   element publishingCountry {
+			       attribute id { text },
+			       text
+			   }?
 		       }
 
   description = element description {

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -20,11 +20,12 @@ grammar {
 
   pageCollectionMetadata = element pageCollectionMetadata{
 			       attribute rocc_id { text },
+			       attribute pageCollectionURL { xsd:anyURI },
 			       attribute title { text },
 			       attribute shortTitle { text },
 			       attribute language { text },
-			       attribute metadataCreator { text },
-			       attribute distribution { text },
+			       attribute metadataCreator { xsd:anyURI },
+			       attribute distribution { xsd:anyURI },
 			       roccCode,
 			       translation?,
 			       scannedCopy,

--- a/rocc.rnc
+++ b/rocc.rnc
@@ -182,6 +182,7 @@ grammar {
 
   onePageImage = element onePageImage {
 		     attribute pageID { text },
+		     attribute pageName { text },
 		     attribute pageImageFile { xsd:anyURI },
 		     difficultyCriteria
 		 }

--- a/rocc.rng
+++ b/rocc.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar ns="https://deloro.iit.academiaromana-is.ro/rocc" xmlns:rnc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar ns="https://deloro.iit.academiaromana-is.ro/rocc" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
     <ref name="ROCC"/>
   </start>
@@ -97,28 +97,6 @@
       </oneOrMore>
     </element>
   </define>
-  <define name="rocCodeZone">
-    <rnc:documentation>Represents the zone of the origin of the document.
-The value can any combination of the following:
-MD = Moldavia
-W = Wallachia
-T = Transylvania
-MM = Maramureș
-BT = Banat
-BS = Bessarabia (for dates between 1812 - 1899)</rnc:documentation>
-    <list>
-      <oneOrMore>
-        <choice>
-          <value>MD</value>
-          <value>W</value>
-          <value>T</value>
-          <value>MM</value>
-          <value>BT</value>
-          <value>BS</value>
-        </choice>
-      </oneOrMore>
-    </list>
-  </define>
   <define name="roccCode">
     <element name="ROCC-code">
       <attribute name="difficultyLevel">
@@ -160,8 +138,8 @@ BS = Bessarabia (for dates between 1812 - 1899)</rnc:documentation>
       <attribute name="printingYear">
         <data type="integer"/>
       </attribute>
-      <attribute name="zone">
-        <ref name="rocCodeZone"/>
+      <attribute name="locationRoot">
+        <data type="anyURI"/>
       </attribute>
     </element>
   </define>

--- a/rocc.rng
+++ b/rocc.rng
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar ns="https://deloro.iit.academiaromana-is.ro/rocc" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar ns="https://deloro.iit.academiaromana-is.ro/rocc" xmlns:rnc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
     <ref name="ROCC"/>
   </start>
   <!-- Root element of the ROCC file. -->
   <define name="ROCC">
     <element name="ROCC">
-      <ref name="pageCollection"/>
+      <oneOrMore>
+        <ref name="pageCollection"/>
+      </oneOrMore>
     </element>
   </define>
   <define name="pageCollection">
@@ -27,11 +29,18 @@
   <define name="pageCollectionMetadata">
     <element name="pageCollectionMetadata">
       <attribute name="rocc_id"/>
+      <attribute name="pageCollectionURL">
+        <data type="anyURI"/>
+      </attribute>
       <attribute name="title"/>
       <attribute name="shortTitle"/>
       <attribute name="language"/>
-      <attribute name="metadataCreator"/>
-      <attribute name="distribution"/>
+      <attribute name="metadataCreator">
+        <data type="anyURI"/>
+      </attribute>
+      <attribute name="distribution">
+        <data type="anyURI"/>
+      </attribute>
       <ref name="roccCode"/>
       <optional>
         <ref name="translation"/>
@@ -39,7 +48,10 @@
       <ref name="scannedCopy"/>
       <ref name="creation"/>
       <ref name="publishing"/>
-      <ref name="description"/>
+      <ref name="contentDescription"/>
+      <zeroOrMore>
+        <ref name="formatDescription"/>
+      </zeroOrMore>
     </element>
   </define>
   <define name="imagesOfPages">
@@ -97,6 +109,28 @@
       </oneOrMore>
     </element>
   </define>
+  <define name="roccCodeZone">
+    <rnc:documentation>Represents the zone of the origin of the document.
+The value can any combination of the following:
+MD = Moldavia
+W  = Wallachia
+T  = Transylvania
+MM = Maramureș
+BT = Banat
+BS = Bessarabia (for dates between 1812 - 1899)</rnc:documentation>
+    <list>
+      <oneOrMore>
+        <choice>
+          <value>MD</value>
+          <value>W</value>
+          <value>T</value>
+          <value>MM</value>
+          <value>BT</value>
+          <value>BS</value>
+        </choice>
+      </oneOrMore>
+    </list>
+  </define>
   <define name="roccCode">
     <element name="ROCC-code">
       <attribute name="difficultyLevel">
@@ -107,18 +141,31 @@
         </choice>
       </attribute>
       <attribute name="writingType">
+        <rnc:documentation>Denotes the type of writing of the page collection.
+Values for writingType attribute are:
+- p  = print;
+- u  = uncial;
+- su = semiuncial;
+- m  = manuscript.</rnc:documentation>
         <choice>
-          <value>print</value>
-          <value>uncial</value>
-          <value>manuscript</value>
+          <value>p</value>
+          <value>u</value>
+          <value>su</value>
+          <value>m</value>
         </choice>
       </attribute>
       <attribute name="annotationLevel">
+        <rnc:documentation>Denotes the annotation of the page collection.
+Values for annotationLevel attribute are:
+- o = original, unannotated;
+- g = gold - annotated fully or partially by experts;
+- t = test - annotated by the application;
+- m = mixt - annotated by both experts and applications.</rnc:documentation>
         <choice>
-          <value>original</value>
-          <value>gold</value>
-          <value>test</value>
-          <value>mixt</value>
+          <value>o</value>
+          <value>g</value>
+          <value>t</value>
+          <value>m</value>
         </choice>
       </attribute>
       <attribute name="century">
@@ -138,8 +185,8 @@
       <attribute name="printingYear">
         <data type="integer"/>
       </attribute>
-      <attribute name="locationRoot">
-        <data type="anyURI"/>
+      <attribute name="zone">
+        <ref name="roccCodeZone"/>
       </attribute>
     </element>
   </define>
@@ -159,11 +206,64 @@
   </define>
   <define name="creation">
     <element name="creation">
-      <attribute name="author"/>
       <attribute name="creationYear"/>
-      <attribute name="secAuthors"/>
+      <optional>
+        <ref name="author"/>
+      </optional>
+      <zeroOrMore>
+        <ref name="secondaryAuthor"/>
+      </zeroOrMore>
       <optional>
         <ref name="creationLocation"/>
+      </optional>
+    </element>
+  </define>
+  <define name="author">
+    <element name="author">
+      <optional>
+        <attribute name="name"/>
+      </optional>
+      <optional>
+        <attribute name="surname"/>
+      </optional>
+      <optional>
+        <attribute name="content"/>
+      </optional>
+      <optional>
+        <element name="addToName">
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <element name="bio">
+          <text/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="secondaryAuthor">
+    <element name="secAuthor">
+      <attribute name="id"/>
+      <optional>
+        <attribute name="name"/>
+      </optional>
+      <optional>
+        <attribute name="surname"/>
+      </optional>
+      <optional>
+        <attribute name="authority"/>
+      </optional>
+      <optional>
+        <element name="addToName">
+          <attribute name="id"/>
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <element name="bio">
+          <attribute name="id"/>
+          <text/>
+        </element>
       </optional>
     </element>
   </define>
@@ -186,6 +286,30 @@
       <attribute name="publishingYear">
         <data type="integer"/>
       </attribute>
+      <attribute name="publisher"/>
+      <attribute name="noOfPagesOrSheets">
+        <data type="integer"/>
+      </attribute>
+      <attribute name="pageOrSheet">
+        <choice>
+          <value>page</value>
+          <value>sheet</value>
+        </choice>
+      </attribute>
+      <element name="dimensions">
+        <attribute name="units">
+          <choice>
+            <value>mm</value>
+            <value>cm</value>
+          </choice>
+        </attribute>
+        <attribute name="width">
+          <data type="decimal"/>
+        </attribute>
+        <attribute name="height">
+          <data type="decimal"/>
+        </attribute>
+      </element>
       <optional>
         <ref name="publishingLocation"/>
       </optional>
@@ -193,9 +317,6 @@
   </define>
   <define name="publishingLocation">
     <element name="publishingLocation">
-      <optional>
-        <attribute name="publishingCountry"/>
-      </optional>
       <attribute name="publishingProvince">
         <choice>
           <value>Moldova</value>
@@ -205,32 +326,44 @@
         </choice>
       </attribute>
       <optional>
-        <attribute name="publishingHouse"/>
+        <attribute name="publishingTown"/>
       </optional>
       <optional>
-        <attribute name="publishingTown"/>
+        <element name="publishingHouse">
+          <attribute name="id"/>
+          <text/>
+        </element>
+      </optional>
+      <optional>
+        <element name="publishingCountry">
+          <attribute name="id"/>
+          <text/>
+        </element>
       </optional>
     </element>
   </define>
-  <define name="description">
-    <element name="description">
-      <attribute name="style">
-        <choice>
-          <value>Juridic-administrativ</value>
-          <value>Bisericesc</value>
-          <value>Științific</value>
-          <value>Beletristic</value>
-          <value>Publicistic</value>
-        </choice>
-      </attribute>
+  <define name="contentDescription">
+    <element name="contentDescription">
+      <attribute name="style"/>
       <optional>
-        <attribute name="subject"/>
+        <element name="subject">
+          <text/>
+        </element>
       </optional>
+    </element>
+  </define>
+  <define name="formatDescription">
+    <element name="formatDescription">
+      <element name="content">
+        <attribute name="id"/>
+        <text/>
+      </element>
     </element>
   </define>
   <define name="onePageImage">
     <element name="onePageImage">
       <attribute name="pageID"/>
+      <attribute name="pageName"/>
       <attribute name="pageImageFile">
         <data type="anyURI"/>
       </attribute>

--- a/rocc.xml
+++ b/rocc.xml
@@ -2,7 +2,7 @@
 <ROCC xmlns="https://deloro.iit.academiaromana-is.ro/rocc">
   <pageCollection id="">
     <pageCollectionMetadata rocc_id="" title="" shortTitle="" language="" metadataCreator="" distribution="">
-      <ROCC-code difficultyLevel="2" writingType="print" annotationLevel="test" century="XIX" printingYear="1815" fiftyYears="1" zone="MD T W"/>
+      <ROCC-code difficultyLevel="2" writingType="print" annotationLevel="test" century="XIX" printingYear="1815" fiftyYears="1" locationRoot="./data/sec-xix/print/crv-1376-plesoianu-abecedar"/>
       <translation originalLanguage="" originalAuthor="" translator="" secTranslator=""/>
       <scannedCopy library="" libraryCode=""/>
       <creation author="" secAuthors="" creationYear="">

--- a/rocc.xml
+++ b/rocc.xml
@@ -1,20 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ROCC xmlns="https://deloro.iit.academiaromana-is.ro/rocc">
   <pageCollection id="">
-    <pageCollectionMetadata rocc_id="" title="" shortTitle="" language="" metadataCreator="" distribution="">
-      <ROCC-code difficultyLevel="2" writingType="print" annotationLevel="test" century="XIX" printingYear="1815" fiftyYears="1" locationRoot="./data/sec-xix/print/crv-1376-plesoianu-abecedar"/>
+    <pageCollectionMetadata rocc_id="" title="" shortTitle="" language="" metadataCreator="" distribution="" pageCollectionURL="https://deloro.iit.academiaromana-is.ro/rocc/sec-xix-1/tipar/crv-859-tichindeal/">
+      <ROCC-code difficultyLevel="2" writingType="p" annotationLevel="t" century="XIX" printingYear="1815" fiftyYears="1" zone="MD" />
       <translation originalLanguage="" originalAuthor="" translator="" secTranslator=""/>
       <scannedCopy library="" libraryCode=""/>
-      <creation author="" secAuthors="" creationYear="">
+      <creation creationYear="1814">
+	<author name="" surname="" content="" />
         <creationLocation creationProvince="Moldova" creationTown=""/>
       </creation>
-      <publishing publishingYear="1815">
-        <publishingLocation publishingCountry="" publishingProvince="Moldova" publishingTown="" publishingHouse=""/>
+      <publishing publishingYear="1814" publisher="" noOfPagesOrSheets="100" pageOrSheet="page">
+	<dimensions units="cm" width="9" height="14" />
+        <publishingLocation publishingProvince="Moldova" publishingTown="" >
+	  <publishingHouse id="1"></publishingHouse>
+	  <publishingCountry id="1"></publishingCountry>
+	</publishingLocation>
       </publishing>
-      <description style="Bisericesc" subject=""/>
+      <contentDescription style="Bisericesc">
+	<subject />
+      </contentDescription>
+      <formatDescription>
+	<content id="" />
+      </formatDescription>
     </pageCollectionMetadata>
     <imagesOfPages>
-      <onePageImage pageID="" pageImageFile="">
+      <onePageImage pageID="" pageName="tichindeal-1-pagina-1.png" pageImageFile="">
         <difficultyCriteria damaged="false" opaqueSpots="false" transparentPaper="false" overlayPrint="false" interlineWriting="false" palimpsest="false" corrections="none" marginalWriting="none"/>
       </onePageImage>
     </imagesOfPages>

--- a/rocc.xsd
+++ b/rocc.xsd
@@ -79,35 +79,6 @@
       <xs:group maxOccurs="unbounded" ref="rocc:sequenceOnePageAlignments"/>
     </xs:complexType>
   </xs:element>
-  <xs:simpleType name="rocCodeZone">
-    <xs:annotation>
-      <xs:documentation>Represents the zone of the origin of the document.
-The value can any combination of the following:
-MD = Moldavia
-W = Wallachia
-T = Transylvania
-MM = Maramureș
-BT = Banat
-BS = Bessarabia (for dates between 1812 - 1899)</xs:documentation>
-    </xs:annotation>
-    <xs:restriction>
-      <xs:simpleType>
-        <xs:list>
-          <xs:simpleType>
-            <xs:restriction base="xs:token">
-              <xs:enumeration value="MD"/>
-              <xs:enumeration value="W"/>
-              <xs:enumeration value="T"/>
-              <xs:enumeration value="MM"/>
-              <xs:enumeration value="BT"/>
-              <xs:enumeration value="BS"/>
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:list>
-      </xs:simpleType>
-      <xs:minLength value="1"/>
-    </xs:restriction>
-  </xs:simpleType>
   <xs:element name="ROCC-code">
     <xs:complexType>
       <xs:attribute name="difficultyLevel" use="required">
@@ -157,7 +128,7 @@ BS = Bessarabia (for dates between 1812 - 1899)</xs:documentation>
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="printingYear" use="required" type="xs:integer"/>
-      <xs:attribute name="zone" use="required" type="rocc:rocCodeZone"/>
+      <xs:attribute name="locationRoot" use="required" type="xs:anyURI"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="translation">

--- a/rocc.xsd
+++ b/rocc.xsd
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://deloro.iit.academiaromana-is.ro/rocc" xmlns:rocc="https://deloro.iit.academiaromana-is.ro/rocc">
   <!-- Root element of the ROCC file. -->
-  <xs:element name="ROCC" type="rocc:pageCollection"/>
-  <xs:complexType name="pageCollection">
-    <xs:sequence>
-      <xs:element ref="rocc:pageCollection"/>
-    </xs:sequence>
-  </xs:complexType>
+  <xs:element name="ROCC">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="rocc:pageCollection"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="pageCollection">
     <xs:complexType>
       <xs:sequence>
@@ -28,14 +29,16 @@
         <xs:element ref="rocc:scannedCopy"/>
         <xs:element ref="rocc:creation"/>
         <xs:element ref="rocc:publishing"/>
-        <xs:element ref="rocc:description"/>
+        <xs:element ref="rocc:contentDescription"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="rocc:formatDescription"/>
       </xs:sequence>
       <xs:attribute name="rocc_id" use="required"/>
+      <xs:attribute name="pageCollectionURL" use="required" type="xs:anyURI"/>
       <xs:attribute name="title" use="required"/>
       <xs:attribute name="shortTitle" use="required"/>
       <xs:attribute name="language" use="required"/>
-      <xs:attribute name="metadataCreator" use="required"/>
-      <xs:attribute name="distribution" use="required"/>
+      <xs:attribute name="metadataCreator" use="required" type="xs:anyURI"/>
+      <xs:attribute name="distribution" use="required" type="xs:anyURI"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="imagesOfPages">
@@ -79,6 +82,35 @@
       <xs:group maxOccurs="unbounded" ref="rocc:sequenceOnePageAlignments"/>
     </xs:complexType>
   </xs:element>
+  <xs:simpleType name="roccCodeZone">
+    <xs:annotation>
+      <xs:documentation>Represents the zone of the origin of the document.
+The value can any combination of the following:
+MD = Moldavia
+W  = Wallachia
+T  = Transylvania
+MM = Maramureș
+BT = Banat
+BS = Bessarabia (for dates between 1812 - 1899)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="MD"/>
+              <xs:enumeration value="W"/>
+              <xs:enumeration value="T"/>
+              <xs:enumeration value="MM"/>
+              <xs:enumeration value="BT"/>
+              <xs:enumeration value="BS"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:element name="ROCC-code">
     <xs:complexType>
       <xs:attribute name="difficultyLevel" use="required">
@@ -91,21 +123,38 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="writingType" use="required">
+        <xs:annotation>
+          <xs:documentation>Denotes the type of writing of the page collection.
+Values for writingType attribute are:
+- p  = print;
+- u  = uncial;
+- su = semiuncial;
+- m  = manuscript.</xs:documentation>
+        </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:token">
-            <xs:enumeration value="print"/>
-            <xs:enumeration value="uncial"/>
-            <xs:enumeration value="manuscript"/>
+            <xs:enumeration value="p"/>
+            <xs:enumeration value="u"/>
+            <xs:enumeration value="su"/>
+            <xs:enumeration value="m"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="annotationLevel" use="required">
+        <xs:annotation>
+          <xs:documentation>Denotes the annotation of the page collection.
+Values for annotationLevel attribute are:
+- o = original, unannotated;
+- g = gold - annotated fully or partially by experts;
+- t = test - annotated by the application;
+- m = mixt - annotated by both experts and applications.</xs:documentation>
+        </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:token">
-            <xs:enumeration value="original"/>
-            <xs:enumeration value="gold"/>
-            <xs:enumeration value="test"/>
-            <xs:enumeration value="mixt"/>
+            <xs:enumeration value="o"/>
+            <xs:enumeration value="g"/>
+            <xs:enumeration value="t"/>
+            <xs:enumeration value="m"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
@@ -128,7 +177,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="printingYear" use="required" type="xs:integer"/>
-      <xs:attribute name="locationRoot" use="required" type="xs:anyURI"/>
+      <xs:attribute name="zone" use="required" type="rocc:roccCodeZone"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="translation">
@@ -148,11 +197,42 @@
   <xs:element name="creation">
     <xs:complexType>
       <xs:sequence>
+        <xs:element minOccurs="0" ref="rocc:author"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="rocc:secAuthor"/>
         <xs:element minOccurs="0" ref="rocc:creationLocation"/>
       </xs:sequence>
-      <xs:attribute name="author" use="required"/>
       <xs:attribute name="creationYear" use="required"/>
-      <xs:attribute name="secAuthors" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" name="addToName" type="xs:string"/>
+        <xs:element minOccurs="0" name="bio" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="name"/>
+      <xs:attribute name="surname"/>
+      <xs:attribute name="content"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="secAuthor">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" name="addToName">
+          <xs:complexType mixed="true">
+            <xs:attribute name="id" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" name="bio">
+          <xs:complexType mixed="true">
+            <xs:attribute name="id" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="id" use="required"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="surname"/>
+      <xs:attribute name="authority"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="creationLocation">
@@ -172,14 +252,42 @@
   <xs:element name="publishing">
     <xs:complexType>
       <xs:sequence>
+        <xs:element ref="rocc:dimensions"/>
         <xs:element minOccurs="0" ref="rocc:publishingLocation"/>
       </xs:sequence>
       <xs:attribute name="publishingYear" use="required" type="xs:integer"/>
+      <xs:attribute name="publisher" use="required"/>
+      <xs:attribute name="noOfPagesOrSheets" use="required" type="xs:integer"/>
+      <xs:attribute name="pageOrSheet" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="page"/>
+            <xs:enumeration value="sheet"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="dimensions">
+    <xs:complexType>
+      <xs:attribute name="units" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="mm"/>
+            <xs:enumeration value="cm"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width" use="required" type="xs:decimal"/>
+      <xs:attribute name="height" use="required" type="xs:decimal"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="publishingLocation">
     <xs:complexType>
-      <xs:attribute name="publishingCountry"/>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="rocc:publishingHouse"/>
+        <xs:element minOccurs="0" ref="rocc:publishingCountry"/>
+      </xs:sequence>
       <xs:attribute name="publishingProvince" use="required">
         <xs:simpleType>
           <xs:restriction base="xs:token">
@@ -190,24 +298,38 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="publishingHouse"/>
       <xs:attribute name="publishingTown"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="description">
+  <xs:element name="publishingHouse">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publishingCountry">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contentDescription">
     <xs:complexType>
-      <xs:attribute name="style" use="required">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="Juridic-administrativ"/>
-            <xs:enumeration value="Bisericesc"/>
-            <xs:enumeration value="Științific"/>
-            <xs:enumeration value="Beletristic"/>
-            <xs:enumeration value="Publicistic"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="subject"/>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="rocc:subject"/>
+      </xs:sequence>
+      <xs:attribute name="style" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subject" type="xs:string"/>
+  <xs:element name="formatDescription">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="rocc:content"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="content">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="required"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="onePageImage">
@@ -215,6 +337,7 @@
       <xs:complexContent>
         <xs:extension base="rocc:difficultyCriteria">
           <xs:attribute name="pageID" use="required"/>
+          <xs:attribute name="pageName" use="required"/>
           <xs:attribute name="pageImageFile" use="required" type="xs:anyURI"/>
         </xs:extension>
       </xs:complexContent>


### PR DESCRIPTION
The attribute `zone` from the `ROCC-code` element was replaced with the `locationRoot` attribute. This new attribute will reference the root location of a document from the corpus.