### PR TITLE
Attributes in translation element are not properly specified

### DIFF
--- a/rocc.rnc
+++ b/rocc.rnc
@@ -96,10 +96,10 @@ grammar {
 	     }
 
   translation = element translation {
-		    attribute originalAuthor { text },
+		    attribute originalAuthor { text }?,
 		    attribute originalLanguage { text },
-		    attribute secTranslator { text },
-		    attribute translator { text }
+		    attribute secTranslator { text }?,
+		    attribute translator { text }?
 		}
 
   scannedCopy = element scannedCopy {

--- a/rocc.rng
+++ b/rocc.rng
@@ -192,10 +192,16 @@ Values for annotationLevel attribute are:
   </define>
   <define name="translation">
     <element name="translation">
-      <attribute name="originalAuthor"/>
+      <optional>
+        <attribute name="originalAuthor"/>
+      </optional>
       <attribute name="originalLanguage"/>
-      <attribute name="secTranslator"/>
-      <attribute name="translator"/>
+      <optional>
+        <attribute name="secTranslator"/>
+      </optional>
+      <optional>
+        <attribute name="translator"/>
+      </optional>
     </element>
   </define>
   <define name="scannedCopy">

--- a/rocc.xsd
+++ b/rocc.xsd
@@ -182,10 +182,10 @@ Values for annotationLevel attribute are:
   </xs:element>
   <xs:element name="translation">
     <xs:complexType>
-      <xs:attribute name="originalAuthor" use="required"/>
+      <xs:attribute name="originalAuthor"/>
       <xs:attribute name="originalLanguage" use="required"/>
-      <xs:attribute name="secTranslator" use="required"/>
-      <xs:attribute name="translator" use="required"/>
+      <xs:attribute name="secTranslator"/>
+      <xs:attribute name="translator"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="scannedCopy">


### PR DESCRIPTION
All attributes except `originalLanguage` should be optional.