### PR TITLE
Changed column writingtype to character varying(2)

### DIFF
--- a/database/01-rocc-schema.sql
+++ b/database/01-rocc-schema.sql
@@ -1404,7 +1404,7 @@ CREATE TABLE public.rocccodes (
     id integer NOT NULL,
     metadataid integer NOT NULL,
     difficultylevel integer NOT NULL,
-    writingtype character(2) NOT NULL,
+    writingtype character varying(2) NOT NULL,
     annotationlevel character(1) NOT NULL,
     century character varying(5) NOT NULL,
     fiftyyears integer NOT NULL,


### PR DESCRIPTION
Updated type of column `rocccodes.writingtype` to `character varying(2)`.

This pull-request closes #16.