### PR TITLE
Added obliquelines column

### DIFF
--- a/database/01-rocc-schema.sql
+++ b/database/01-rocc-schema.sql
@@ -379,7 +379,8 @@ CREATE TABLE public.difficultycriteria (
     interlinewriting boolean NOT NULL,
     palimpsest boolean NOT NULL,
     corrections character varying(4) NOT NULL,
-    marginalwriting character varying(4) NOT NULL
+    marginalwriting character varying(4) NOT NULL,
+    obliquelines boolean NOT NULL
 );
 
 


### PR DESCRIPTION
Added `obliquelines` column to table `difficultycriteria`. The column is added without a default value and with `not null`.

Closes #20.